### PR TITLE
Revert "Added coverage result one-liner to status check. Reads out of newCode…"

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus.java
@@ -48,8 +48,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
 
     private final Boolean addTestResults;
 
-    private final Boolean addCoverageResults;
-
     private final List<GhprbBuildResultMessage> completedStatus;
 
     public GhprbSimpleStatus() {
@@ -57,7 +55,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements
     }
 
     public GhprbSimpleStatus(String commitStatusContext) {
-        this(false, commitStatusContext, null, null, null, false, false, new ArrayList<GhprbBuildResultMessage>(0));
+        this(false, commitStatusContext, null, null, null, false, new ArrayList<GhprbBuildResultMessage>(0));
     }
 
     @DataBoundConstructor
@@ -67,7 +65,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
                              String triggeredStatus,
                              String startedStatus,
                              Boolean addTestResults,
-                             Boolean addCoverageResults,
                              List<GhprbBuildResultMessage> completedStatus) {
         this.showMatrixStatus = showMatrixStatus;
         this.statusUrl = statusUrl;
@@ -75,7 +72,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
         this.triggeredStatus = triggeredStatus;
         this.startedStatus = startedStatus;
         this.addTestResults = addTestResults;
-        this.addCoverageResults = addCoverageResults;
         this.completedStatus = completedStatus;
     }
 
@@ -101,10 +97,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
 
     public Boolean getAddTestResults() {
         return addTestResults == null ? Boolean.valueOf(false) : addTestResults;
-    }
-
-    public Boolean getAddCoverageResults() {
-        return addCoverageResults == null ? Boolean.valueOf(false) : addCoverageResults;
     }
 
     public List<GhprbBuildResultMessage> getCompletedStatus() {
@@ -223,26 +215,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
                 listener.getLogger().println("Adding one-line test results to commit status...");
                 sb.append(buildManager.getOneLineTestResults());
             }
-            if (getAddCoverageResults()) {
-                listener.getLogger().println("Adding coverage results to commit status...");
-
-                String coverageResultString;
-                GHCommitState coverageState;
-                Map<String, String> envVars = Ghprb.getEnvVars(build, listener);
-                if (!envVars.containsKey("newCodeCoveragePercentage")) {
-                    coverageResultString = "No coverage results found.";
-                    coverageState = GHCommitState.SUCCESS;
-                } else {
-                    String newCodeCoveragePercentage = envVars.get("newCodeCoveragePercentage");
-                    coverageResultString = newCodeCoveragePercentage + "% line coverage on new code.";
-                    int coveragePercent = Integer.parseInt(newCodeCoveragePercentage);
-                    coverageState = coveragePercent > 1 ? GHCommitState.SUCCESS : GHCommitState.ERROR;
-                }
-
-                String context = Util.fixEmpty(commitStatusContext);
-                context = Ghprb.replaceMacros(build, listener, context) + " Coverage";
-                createCommitStatus(build, listener, coverageResultString, repo, coverageState, context);
-            }
         }
 
         createCommitStatus(build, listener, sb.toString(), repo, state);
@@ -252,8 +224,7 @@ public class GhprbSimpleStatus extends GhprbExtension implements
                                     TaskListener listener,
                                     String message,
                                     GHRepository repo,
-                                    GHCommitState state,
-                                    String context) throws GhprbCommitStatusException {
+                                    GHCommitState state) throws GhprbCommitStatusException {
 
         Map<String, String> envVars = Ghprb.getEnvVars(build, listener);
 
@@ -274,6 +245,9 @@ public class GhprbSimpleStatus extends GhprbExtension implements
             url = Ghprb.replaceMacros(build, listener, statusUrl);
         }
 
+        String context = Util.fixEmpty(commitStatusContext);
+        context = Ghprb.replaceMacros(build, listener, context);
+
         listener.getLogger().println(String.format("Setting status of %s to %s with url %s and message: '%s'",
                 sha1,
                 state,
@@ -289,16 +263,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
         } catch (IOException e) {
             throw new GhprbCommitStatusException(e, state, message, pullId);
         }
-    }
-
-    private void createCommitStatus(Run<?, ?> build,
-                                    TaskListener listener,
-                                    String message,
-                                    GHRepository repo,
-                                    GHCommitState state) throws GhprbCommitStatusException {
-        String context = Util.fixEmpty(commitStatusContext);
-        context = Ghprb.replaceMacros(build, listener, context);
-        createCommitStatus(build, listener, message, repo, state, context);
     }
 
     public void createCommitStatus(Job<?, ?> project,
@@ -355,10 +319,6 @@ public class GhprbSimpleStatus extends GhprbExtension implements
 
         public Boolean getAddTestResultsDefault(GhprbSimpleStatus local) {
             return Ghprb.getDefaultValue(local, GhprbSimpleStatus.class, "getAddTestResults");
-        }
-
-        public Boolean getAddCoverageResultsDefault(GhprbSimpleStatus local) {
-            return Ghprb.getDefaultValue(local, GhprbSimpleStatus.class, "getAddCoverageResults");
         }
 
         public List<GhprbBuildResultMessage> getCompletedStatusDefault(GhprbSimpleStatus local) {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusDescriptor.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusDescriptor.java
@@ -16,8 +16,6 @@ public abstract class GhprbSimpleStatusDescriptor extends GhprbExtensionDescript
 
     public abstract Boolean getAddTestResultsDefault(GhprbSimpleStatus local);
 
-    public abstract Boolean getAddCoverageResultsDefault(GhprbSimpleStatus local);
-
     public abstract List<GhprbBuildResultMessage> getCompletedStatusDefault(GhprbSimpleStatus local);
 
     public abstract String getCommitStatusContextDefault(GhprbSimpleStatus local);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -76,7 +76,6 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 context.triggeredStatus,
                 context.startedStatus,
                 context.addTestResults,
-                context.addCoverageResults,
                 context.completedStatus
         );
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbExtensionContext.java
@@ -26,7 +26,6 @@ class GhprbExtensionContext implements Context {
                 context.triggeredStatus,
                 context.startedStatus,
                 context.addTestResults,
-                context.addCoverageResults,
                 context.completedStatus
         ));
     }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbSimpleStatusContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbSimpleStatusContext.java
@@ -20,8 +20,6 @@ class GhprbSimpleStatusContext implements Context {
 
     Boolean addTestResults;
 
-    Boolean addCoverageResults;
-
     List<GhprbBuildResultMessage> completedStatus = new ArrayList<GhprbBuildResultMessage>();
 
     /**
@@ -71,13 +69,6 @@ class GhprbSimpleStatusContext implements Context {
      */
     void addTestResults(Boolean addTestResults) {
         this.addTestResults = addTestResults;
-    }
-
-    /**
-     * Add the coverage results as one line if available.
-     */
-    void addCoverageResults(Boolean addCoverageResults) {
-        this.addCoverageResults = addCoverageResults;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbUpstreamStatusContext.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbUpstreamStatusContext.java
@@ -20,8 +20,6 @@ class GhprbUpstreamStatusContext implements Context {
 
     Boolean addTestResults;
 
-    Boolean addCoverageResults;
-
     List<GhprbBuildResultMessage> completedStatus = new ArrayList<GhprbBuildResultMessage>();
 
     /**
@@ -71,13 +69,6 @@ class GhprbUpstreamStatusContext implements Context {
      */
     void addTestResults(Boolean addTestResults) {
         this.addTestResults = addTestResults;
-    }
-
-    /**
-     * Add the coverage results if available.
-     */
-    void addCoverageResults(Boolean addCoverageResults) {
-        this.addCoverageResults = addCoverageResults;
     }
 
     /**

--- a/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/manager/impl/GhprbBaseBuildManager.java
@@ -8,15 +8,16 @@ import hudson.tasks.junit.TestResult;
 import hudson.tasks.test.AbstractTestResultAction;
 import hudson.tasks.test.AggregatedTestResultAction;
 import hudson.tasks.test.AggregatedTestResultAction.ChildReport;
+import jenkins.model.Jenkins;
+import org.jenkinsci.plugins.ghprb.manager.GhprbBuildManager;
+import org.jenkinsci.plugins.ghprb.manager.configuration.JobConfiguration;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-import jenkins.model.Jenkins;
-import org.jenkinsci.plugins.ghprb.manager.GhprbBuildManager;
-import org.jenkinsci.plugins.ghprb.manager.configuration.JobConfiguration;
 
 /**
  * @author mdelapenya (Manuel de la Peña)

--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus.java
@@ -36,8 +36,6 @@ public class GhprbUpstreamStatus extends BuildWrapper {
 
     private final Boolean addTestResults;
 
-    private final Boolean addCoverageResults;
-
     private final List<GhprbBuildResultMessage> completedStatus;
 
     // sets the context and message as env vars so that they are available in the Listener class
@@ -50,7 +48,6 @@ public class GhprbUpstreamStatus extends BuildWrapper {
         variables.put("ghprbStartedStatus", getStartedStatus());
         variables.put("ghprbStatusUrl", getStatusUrl());
         variables.put("ghprbAddTestResults", Boolean.toString(getAddTestResults()));
-        variables.put("ghprbAddCoverageResults", Boolean.toString(getAddCoverageResults()));
 
         Map<GHCommitState, StringBuilder> statusMessages = new HashMap<GHCommitState, StringBuilder>(INITIAL_CAPACITY);
 
@@ -97,7 +94,6 @@ public class GhprbUpstreamStatus extends BuildWrapper {
             String triggeredStatus,
             String startedStatus,
             Boolean addTestResults,
-            Boolean addCoverageResults,
             List<GhprbBuildResultMessage> completedStatus
     ) {
         this.showMatrixStatus = showMatrixStatus;
@@ -106,7 +102,6 @@ public class GhprbUpstreamStatus extends BuildWrapper {
         this.triggeredStatus = triggeredStatus;
         this.startedStatus = startedStatus;
         this.addTestResults = addTestResults;
-        this.addCoverageResults = addCoverageResults;
         this.completedStatus = completedStatus;
     }
 
@@ -129,10 +124,6 @@ public class GhprbUpstreamStatus extends BuildWrapper {
 
     public Boolean getAddTestResults() {
         return addTestResults == null ? Boolean.valueOf(false) : addTestResults;
-    }
-
-    public Boolean getAddCoverageResults() {
-        return addCoverageResults == null ? Boolean.valueOf(false) : addCoverageResults;
     }
 
     public Boolean getShowMatrixStatus() {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatusListener.java
@@ -75,7 +75,6 @@ public class GhprbUpstreamStatusListener extends RunListener<AbstractBuild<?, ?>
                 envVars.get("ghprbTriggeredStatus"),
                 envVars.get("ghprbStartedStatus"),
                 Boolean.valueOf(envVars.get("ghprbAddTestResults")),
-                Boolean.valueOf(envVars.get("ghprbAddCoverageResults")),
                 statusMessages
         );
     }

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatus/config.jelly
@@ -15,9 +15,6 @@
   <f:entry title="${%Add test result one liner}" field="addTestResults" >
     <f:checkbox default="${descriptor.getAddTestResultsDefault(instance)}" />
   </f:entry>
-  <f:entry title="${%Add coverage result one liner}" field="addCoverageResults" >
-    <f:checkbox default="${descriptor.getAddCoverageResultsDefault(instance)}" />
-  </f:entry>
   <f:entry title="${%Commit Status Build Result}" field="completedStatus" >
     <f:repeatableProperty field="completedStatus" default="${descriptor.getCompletedStatusDefault(instance)}" />
   </f:entry>

--- a/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
+++ b/src/main/resources/org/jenkinsci/plugins/ghprb/upstream/GhprbUpstreamStatus/config.jelly
@@ -18,9 +18,6 @@
   <f:entry title="${%Add test result one liner}" field="addTestResults" >
     <f:checkbox default="${descriptor.getAddTestResultsDefault(instance)}" />
   </f:entry>
-  <f:entry title="${%Add coverage result one liner}" field="addCoverageResults" >
-    <f:checkbox default="${descriptor.getAddCoverageResultsDefault(instance)}" />
-  </f:entry>
   <f:entry title="${%Commit Status Build Result}" field="completedStatus" >
     <f:repeatableProperty field="completedStatus" default="${descriptor.getCompletedStatusDefault(instance)}" />
   </f:entry>

--- a/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/extensions/status/GhprbSimpleStatusTest.java
@@ -1,13 +1,5 @@
 package org.jenkinsci.plugins.ghprb.extensions.status;
 
-import static org.mockito.BDDMockito.given;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isNull;
-import static org.mockito.Mockito.spy;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoMoreInteractions;
-
-import java.util.ArrayList;
 import org.jenkinsci.plugins.ghprb.GhprbPullRequest;
 import org.jenkinsci.plugins.ghprb.GhprbTestUtil;
 import org.jenkinsci.plugins.ghprb.GhprbTrigger;
@@ -21,6 +13,15 @@ import org.kohsuke.github.GHCommitState;
 import org.kohsuke.github.GHRepository;
 import org.mockito.Mock;
 import org.mockito.runners.MockitoJUnitRunner;
+
+import java.util.ArrayList;
+
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
 
 @RunWith(MockitoJUnitRunner.class)
 public class GhprbSimpleStatusTest extends org.jenkinsci.plugins.ghprb.extensions.GhprbExtension {
@@ -107,7 +108,7 @@ public class GhprbSimpleStatusTest extends org.jenkinsci.plugins.ghprb.extension
         given(ghprbPullRequest.isMergeable()).willReturn(false);
 
         GhprbSimpleStatus globalStatus =
-                new GhprbSimpleStatus(true, context, statusUrl, "test1", "test2", false, false, new ArrayList<GhprbBuildResultMessage>(0));
+                new GhprbSimpleStatus(true, context, statusUrl, "test1", "test2", false, new ArrayList<GhprbBuildResultMessage>(0));
         GhprbTrigger.getDscp().getExtensions().add(globalStatus);
 
         GhprbSimpleStatus status = new GhprbSimpleStatus("");


### PR DESCRIPTION
Can't do this until we contribute back to GHPRB for the original feature