### PR TITLE
Show PR author's login if the name is empty.

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbPullRequest.java
@@ -340,11 +340,12 @@ public class GhprbPullRequest {
             Date updatedDate = comment != null ? comment.getUpdatedAt() : ghpr.getUpdatedAt();
             // Don't log unless it was actually updated
             if (updated == null || updated.compareTo(updatedDate) < 0) {
-                String user = comment != null ? comment.getUser().getName() : ghpr.getUser().getName();
+                GHUser user = comment != null ? comment.getUser() : ghpr.getUser();
+                String name = StringUtils.defaultIfBlank(user.getName(), user.getLogin());
                 LOGGER.log(
                         Level.INFO,
                         "Pull request #{0} was updated/initialized on {1} at {2} by {3} ({4})",
-                        new Object[] {this.id, this.repo.getName(), updatedDate, user,
+                        new Object[] {this.id, this.repo.getName(), updatedDate, name,
                                 comment != null ? "comment" : "PR update"}
                 );
             }

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -239,6 +239,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(gt);
 
         verify(ghUser, times(1)).getName();
+        verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
         verifyZeroInteractions(ghUser);
     }
@@ -599,7 +600,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(4)).getLogin();
         verify(ghUser, times(3)).getName();
         verifyNoMoreInteractions(ghUser);
     }
@@ -701,7 +702,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(helper);
 
         verify(ghUser, times(1)).getEmail(); // Call to Github API
-        verify(ghUser, times(2)).getLogin();
+        verify(ghUser, times(3)).getLogin();
         verify(ghUser, times(2)).getName();
         verifyNoMoreInteractions(ghUser);
 


### PR DESCRIPTION
This will allow to show user's login instead of `null` when there is no name (e.g. a Github bot), as in the example below.
```
Pull request #13,031 was updated/initialized on Leanplum/Leanplum at 8/7/20 2:24 PM by null (comment)
Aug 07, 2020 2:24:43 PM FINEST org.jenkinsci.plugins.ghprb.GhprbPullRequest
```